### PR TITLE
Interval variable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+0.5.6 (2019-02-22)
+==================
+
+New features
+-----
+* Added support for Interval Variable Type in Template Class
+
+
 0.5.5 (2019-02-13)
 ==================
 

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -725,6 +725,11 @@ class Template(object):
     type = attr.ib(default='query')
     hide = attr.ib(default=SHOW)
 
+    # Interval Variables Specific 
+    auto = attr.ib(default=None)
+    auto_count = attr.ib(default=None)
+    auto_min = attr.ib(default=None)
+
     def __attrs_post_init__(self):
         if self.type == 'custom':
             if len(self.options) == 0:
@@ -769,6 +774,9 @@ class Template(object):
             'useTags': self.useTags,
             'tagsQuery': self.tagsQuery,
             'tagValuesQuery': self.tagValuesQuery,
+            'auto': self.auto,
+            'auto_count': self.auto_count,
+            'auto_min': self.auto_min,
         }
 
 


### PR DESCRIPTION
## What does this do?
Created three new attributes on Template class to support an interval Template Type
- auto
- auto_min
- auto_count

## Why is it a good idea?
Allows use of grafanalib to provision dashboards with these template types

## Context
Original Repository seems dead

## Questions

